### PR TITLE
Add token for pushing tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4


### PR DESCRIPTION
Include a token to enable pushing tags during the CI process.