### PR TITLE
Remove NPM token for trusted publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -257,7 +257,7 @@ jobs:
 
     create-release:
         runs-on: ubuntu-latest
-        needs: [version-and-build, publish-npm, publish-docker]
+        needs: [version-and-build, publish-npm, publish-containers]
 
         permissions:
             contents: write


### PR DESCRIPTION
Eliminate the use of the NPM token in the publish workflow to enhance security. Rename the publish job for clarity.